### PR TITLE
Remove Path Params

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
 	branch = v1.2.0
+[submodule "lib/solidity-stringutils"]
+	path = lib/solidity-stringutils
+	url = https://github.com/Arachnid/solidity-stringutils

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,7 @@ out = 'out'
 ffi = true
 build_info = true
 extra_output = ['storageLayout']
+fs_permissions = [{ access = "read", path = "./"}]
 force = true
 
 [rpc_endpoints]

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,8 @@ src = 'src'
 verbosity = 2
 
 libs = ['lib']
-out = 'out'
+out = 'out/artifacts'
+build_info_path = 'out/artifacts/build-info'
 ffi = true
 build_info = true
 extra_output = ['storageLayout']

--- a/scripts/ChugSplash.s.sol
+++ b/scripts/ChugSplash.s.sol
@@ -17,16 +17,12 @@ contract ChugSplashDeploy is Script {
         string memory configPath = "./chugsplash/config.ts";
         bool silent = false;
         string memory key = vm.envString("PRIVATE_KEY");
-        string memory outPath = vm.envString("OUT_PATH");
-        string memory buildInfoPath = vm.envString("BUILD_INFO_PATH");
-
+        
         chugsplash.register(
             configPath,
             "localhost",
             key, 
             silent,
-            outPath,
-            buildInfoPath,
             "self"
         );
 

--- a/src/contracts/ChugSplash.sol
+++ b/src/contracts/ChugSplash.sol
@@ -3,9 +3,11 @@ pragma solidity ^0.8.17;
 // SPDX-License-Identifier: MIT
 import "forge-std/Script.sol"; 
 import "forge-std/Test.sol"; 
+import "github.com/Arachnid/solidity-stringutils/strings.sol";
 
 contract ChugSplash is Script, Test {
-
+    using strings for *;
+    
     struct ChugSplashContract {
         string referenceName;
         string contractName;
@@ -34,12 +36,24 @@ contract ChugSplash is Script, Test {
         string memory network, 
         string memory privateKey, 
         bool silent, 
-        string memory outPath,
-        string memory buildInfoPath,
         string memory newOwner
     ) external returns (bytes memory) {
         string memory rpcUrl = vm.rpcUrl(network);
         string memory filePath = vm.envOr("DEV_FILE_PATH", string('./lib/ChugSplash/src/index.ts'));
+
+        string outFilePath = './out';
+        string buildInfoOut = './out/build-info';
+        string memory tomlPath = "foundry.toml";
+        string memory line;
+        while (line != "") {
+            line = vm.readLine(tomlPath);
+            if (line.starts("out")) {
+                outFilePath = line.beyond("out");
+            }
+            if (buildInfoOut.starts("build_info_path")) {
+                buildInfoOut = line.beyond("build_info_path");
+            }
+        }
 
         string[] memory cmds = new string[](12);
         cmds[0] = "npx";

--- a/src/contracts/ChugSplash.sol
+++ b/src/contracts/ChugSplash.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.17;
 // SPDX-License-Identifier: MIT
 import "forge-std/Script.sol"; 
 import "forge-std/Test.sol"; 
-import "github.com/Arachnid/solidity-stringutils/strings.sol";
+import "lib/solidity-stringutils/strings.sol";
 
 contract ChugSplash is Script, Test {
     using strings for *;
@@ -23,12 +23,27 @@ contract ChugSplash is Script, Test {
             bytes32 encodedContractName = keccak256(abi.encodePacked(deployedContracts[i].contractName));
             bytes32 encodedReferenceName = keccak256(abi.encodePacked(deployedContracts[i].referenceName));
             if (encodedContractName == keccak256(contractName) && encodedReferenceName == keccak256(referenceName)) {
-                emit log("found contract");
                 return deployedContracts[i].contractAddress;
             }
         }
 
         revert("contract address not found, are you sure you specified the correct contract and reference name");
+    }
+
+    function fetchPaths() private view returns (string memory outPath, string memory buildInfoPath) {
+        outPath = './out';
+        buildInfoPath = './out/build-info';
+        string memory tomlPath = "foundry.toml";
+        strings.slice memory line;
+        while (!line.equals("".toSlice())) {
+            line = vm.readLine(tomlPath).toSlice();
+            if (line.startsWith("out".toSlice())) {
+                outPath = line.beyond("out".toSlice()).toString();
+            }
+            if (line.startsWith("build_info_path".toSlice())) {
+                buildInfoPath = line.beyond("build_info_path".toSlice()).toString();
+            }
+        }
     }
 
     function register(
@@ -41,19 +56,7 @@ contract ChugSplash is Script, Test {
         string memory rpcUrl = vm.rpcUrl(network);
         string memory filePath = vm.envOr("DEV_FILE_PATH", string('./lib/ChugSplash/src/index.ts'));
 
-        string outFilePath = './out';
-        string buildInfoOut = './out/build-info';
-        string memory tomlPath = "foundry.toml";
-        string memory line;
-        while (line != "") {
-            line = vm.readLine(tomlPath);
-            if (line.starts("out")) {
-                outFilePath = line.beyond("out");
-            }
-            if (buildInfoOut.starts("build_info_path")) {
-                buildInfoOut = line.beyond("build_info_path");
-            }
-        }
+        (string memory outPath, string memory buildInfoPath) = fetchPaths();
 
         string[] memory cmds = new string[](12);
         cmds[0] = "npx";
@@ -82,14 +85,14 @@ contract ChugSplash is Script, Test {
         string memory network, 
         string memory privateKey, 
         bool silent, 
-        string memory outPath,
-        string memory buildInfoPath,
         string memory ipfsUrl,
         bool remoteExecution,
         bool skipStorageCheck
     ) external returns (bytes memory) {
         string memory rpcUrl = vm.rpcUrl(network);
         string memory filePath = vm.envOr("DEV_FILE_PATH", string('./lib/ChugSplash/src/index.ts'));
+
+        (string memory outPath, string memory buildInfoPath) = fetchPaths();
 
         string[] memory cmds = new string[](14);
         cmds[0] = "npx";
@@ -121,12 +124,12 @@ contract ChugSplash is Script, Test {
         string memory network, 
         string memory privateKey, 
         bool silent, 
-        string memory outPath,
-        string memory buildInfoPath,
         uint amount 
     ) external returns (bytes memory) {
         string memory rpcUrl = vm.rpcUrl(network);
         string memory filePath = vm.envOr("DEV_FILE_PATH", string('./lib/ChugSplash/src/index.ts'));
+
+        (string memory outPath, string memory buildInfoPath) = fetchPaths();
 
         string[] memory cmds = new string[](12);
         cmds[0] = "npx";
@@ -156,13 +159,13 @@ contract ChugSplash is Script, Test {
         string memory network, 
         string memory privateKey, 
         bool silent, 
-        string memory outPath,
-        string memory buildInfoPath,
         bool withdrawFunds,
         bool skipMonitorStatus
     ) external returns (bytes memory) {
         string memory rpcUrl = vm.rpcUrl(network);
         string memory filePath = vm.envOr("DEV_FILE_PATH", string('./lib/ChugSplash/src/index.ts'));
+
+        (string memory outPath, string memory buildInfoPath) = fetchPaths();
 
         string[] memory cmds = new string[](13);
         cmds[0] = "npx";
@@ -193,8 +196,6 @@ contract ChugSplash is Script, Test {
         string memory network, 
         string memory privateKey, 
         bool silent, 
-        string memory outPath,
-        string memory buildInfoPath,
         bool withdrawFunds,
         string memory newOwner,
         string memory ipfsUrl,
@@ -202,6 +203,8 @@ contract ChugSplash is Script, Test {
     ) external returns (ChugSplashContract[] memory) {
         string memory rpcUrl = vm.rpcUrl(network);
         string memory filePath = vm.envOr("DEV_FILE_PATH", string('./lib/ChugSplash/src/index.ts'));
+
+        (string memory outPath, string memory buildInfoPath) = fetchPaths();
 
         string[] memory cmds = new string[](15);
         cmds[0] = "npx";
@@ -233,12 +236,12 @@ contract ChugSplash is Script, Test {
         string memory network, 
         string memory privateKey, 
         bool silent, 
-        string memory outPath,
-        string memory buildInfoPath,
         string memory newOwner
     ) external returns (bytes memory) {
         string memory rpcUrl = vm.rpcUrl(network);
         string memory filePath = vm.envOr("DEV_FILE_PATH", string('./lib/ChugSplash/src/index.ts'));
+
+        (string memory outPath, string memory buildInfoPath) = fetchPaths();
 
         string[] memory cmds = new string[](12);
         cmds[0] = "npx";
@@ -266,12 +269,12 @@ contract ChugSplash is Script, Test {
     function cancel(
         string memory configPath, 
         string memory network, 
-        string memory privateKey,
-        string memory outPath,
-        string memory buildInfoPath
+        string memory privateKey
     ) external returns (bytes memory) {
         string memory rpcUrl = vm.rpcUrl(network);
         string memory filePath = vm.envOr("DEV_FILE_PATH", string('./lib/ChugSplash/src/index.ts'));
+
+        (string memory outPath, string memory buildInfoPath) = fetchPaths();
 
         string[] memory cmds = new string[](10);
         cmds[0] = "npx";
@@ -298,12 +301,12 @@ contract ChugSplash is Script, Test {
         string memory configPath, 
         string memory network, 
         string memory privateKey, 
-        bool silent, 
-        string memory outPath,
-        string memory buildInfoPath
+        bool silent
     ) external returns (bytes memory) {
         string memory rpcUrl = vm.rpcUrl(network);
         string memory filePath = vm.envOr("DEV_FILE_PATH", string('./lib/ChugSplash/src/index.ts'));
+
+        (string memory outPath, string memory buildInfoPath) = fetchPaths();
 
         string[] memory cmds = new string[](11);
         cmds[0] = "npx";
@@ -355,12 +358,12 @@ contract ChugSplash is Script, Test {
     function listProposers(
         string memory configPath, 
         string memory network, 
-        string memory privateKey,
-        string memory outPath,
-        string memory buildInfoPath
+        string memory privateKey
     ) external returns (bytes memory) {
         string memory rpcUrl = vm.rpcUrl(network);
         string memory filePath = vm.envOr("DEV_FILE_PATH", string('./lib/ChugSplash/src/index.ts'));
+
+        (string memory outPath, string memory buildInfoPath) = fetchPaths();
 
         string[] memory cmds = new string[](10);
         cmds[0] = "npx";
@@ -387,12 +390,12 @@ contract ChugSplash is Script, Test {
         string memory configPath, 
         string memory network, 
         string memory privateKey, 
-        address newProposer,
-        string memory outPath,
-        string memory buildInfoPath
+        address newProposer
     ) external returns (bytes memory) {
         string memory rpcUrl = vm.rpcUrl(network);
         string memory filePath = vm.envOr("DEV_FILE_PATH", string('./lib/ChugSplash/src/index.ts'));
+
+        (string memory outPath, string memory buildInfoPath) = fetchPaths();
 
         string[] memory cmds = new string[](11);
         cmds[0] = "npx";
@@ -421,12 +424,12 @@ contract ChugSplash is Script, Test {
         string memory network, 
         string memory privateKey, 
         bool silent, 
-        string memory outPath,
-        string memory buildInfoPath,
         string memory referenceName
     ) external returns (bytes memory) {
         string memory rpcUrl = vm.rpcUrl(network);
         string memory filePath = vm.envOr("DEV_FILE_PATH", string('./lib/ChugSplash/src/index.ts'));
+
+        (string memory outPath, string memory buildInfoPath) = fetchPaths();
 
         string[] memory cmds = new string[](12);
         cmds[0] = "npx";
@@ -456,12 +459,12 @@ contract ChugSplash is Script, Test {
         string memory network, 
         string memory privateKey, 
         bool silent, 
-        string memory outPath,
-        string memory buildInfoPath,
         address proxyAddress
     ) external returns (bytes memory) {
         string memory rpcUrl = vm.rpcUrl(network);
         string memory filePath = vm.envOr("DEV_FILE_PATH", string('./lib/ChugSplash/src/index.ts'));
+
+        (string memory outPath, string memory buildInfoPath) = fetchPaths();
 
         string[] memory cmds = new string[](12);
         cmds[0] = "npx";

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,7 @@ const command = args[0]
       const skipStorageCheck = args[11] === 'true'
       
       const noCompile = true
-      const confirm = false
+      const confirm = true
 
       const logPath = `reforge/logs/${network ?? "anvil"}`
       if (!fs.existsSync(logPath)) {

--- a/test/ChugSplash.t.sol
+++ b/test/ChugSplash.t.sol
@@ -18,16 +18,12 @@ contract ChugSplashTest is Test, Script {
         string memory configPath = "./chugsplash/config.ts";
         bool silent = false;
         string memory key = vm.envString("PRIVATE_KEY");
-        string memory outPath = vm.envString("OUT_PATH");
-        string memory buildInfoPath = vm.envString("BUILD_INFO_PATH");
 
         ChugSplash.ChugSplashContract[] memory deployedContracts = chugsplash.deploy(
             configPath,
             "localhost",
             key,
             silent,
-            outPath,
-            buildInfoPath,
             false,
             "self",
             "none",


### PR DESCRIPTION
## Purpose
- Removes the need to pass the build info path and out path into chugsplash functions. Instead, they are read from the foundry.toml file
- Fixes an issue where upgrades fail due to waiting for confirmation from the user