### PR TITLE
initiate executor in register task

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -178,7 +178,7 @@ anvil
 In another terminal window, run the following command to deploy your upgradeable contract:
 
 ```
-forge script script/MyFirstProject.s.sol
+forge script --rpc-url localhost script/MyFirstProject.s.sol
 ```
 
 You should see the following output:
@@ -246,7 +246,7 @@ Notice that you need to call `chugsplash.refresh()` after calling `chugsplash.de
 
 Run your tests using the command:
 ```
-forge test
+forge test --rpc-url localhost
 ```
 
 ## 10. Upgrade with ChugSplash
@@ -293,7 +293,7 @@ Then, update your existing ChugSplash file, `hello-chugsplash.json`, to assign a
 
 Then, run the same script that you used to deploy the contract initially:
 ```
-forge script script/MyFirstProject.s.sol
+forge script --rpc-url localhost script/MyFirstProject.s.sol
 ```
 
 You should see the same output as before:

--- a/docs/storage-checker.md
+++ b/docs/storage-checker.md
@@ -1,12 +1,14 @@
 # The Storage Layout Safety Checker
 
-When upgrading contracts, ChugSplash automatically checks that each new contract doesn't have storage layout compatibility issues with its existing contract. These issues can cause the upgraded version of the contract to have its storage values mixed up, which can lead to critical errors in your application. If ChugSplash detects any of these issues, it will throw an error before the upgrade happens.
+Read this guide if you want to learn about the storage layout issues that ChugSplash detects automatically.
 
-This guide explains the storage layout issues that ChugSplash detects automatically.
+When upgrading contracts, ChugSplash automatically checks that each new contract doesn't have storage layout compatibility issues with its existing contract. These issues can cause the upgraded version of the contract to have its storage values mixed up, which can lead to critical errors in your application. If ChugSplash detects any of these issues, it will throw an error before the upgrade happens.
 
 It's worth mentioning that these restrictions have their roots in how the Ethereum VM works, and apply to all tools that manage upgradeable contracts, not just ChugSplash.
 
 If you want to disable these checks, see the `SKIP_STORAGE_CHECK` configuration option [here](https://github.com/chugsplash/chugsplash-foundry/blob/main/docs/live-network.md#optional-variables).
+
+> Note: None of these rules apply to `immutable` and `constant` state variables because the Solidity compiler does not reserve a storage slot for them. [See here](https://solidity.readthedocs.io/en/latest/contracts.html#constant-state-variables) for a further explanation in the Solidity documentation.
 
 ## Correct Pattern
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,13 @@ const command = args[0]
       const address = await wallet.getAddress()
       owner = owner !== "self" ? owner : address
 
+      const remoteExecution = args[3] !== 'localhost'
+      if (remoteExecution) {
+        await monitorChugSplashSetup(provider, wallet)
+      } else {
+        await initializeExecutor(provider, privateKey, "error")
+      }
+
       if (!silent) console.log("-- ChugSplash Register --")
       await chugsplashRegisterAbstractTask(provider, wallet, config, owner, silent, 'foundry', process.stdout)
       break


### PR DESCRIPTION
This fixes an issue where calling `chugsplash.register` then `chugsplash.deploy` was failing.